### PR TITLE
Update build config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ dependencies{
 }
 
 jar{
-    version = null
     from{
         configurations.runtimeClasspath.collect{it.isDirectory() ? it : zipTree(it)}
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Changes

### Update Gradle version to 6.3

Gradle 5.5 is not compatible with Java 14.
Java 14 is only available on gradle 6.3 or higher.

See [Gradle 6.3 Release Notes](https://docs.gradle.org/6.3/release-notes.html).

### Remove deprecated property `jar.version`

The `jar.version` property has been deprecated.
This is scheduled to be removed in Gradle 7.0.

See [Gradle Docs - Jar](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:version).

P.S. How about plugin template using Kotlin? I made it!([mindustry-plugin-kt](https://github.com/Astro36/mindustry-plugin-kt))