### PR TITLE
Update artifact upload action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Build plugin jar
       run: ./gradlew jar
     - name: Upload built jar file
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ github.event.repository.name }}
         path: build/libs/${{ github.event.repository.name }}.jar


### PR DESCRIPTION
GitHub has deprecated & removed upload-artifact v2 & v3.